### PR TITLE
Import ggthemes, include ggpairs plot for some features

### DIFF
--- a/src/seismophobia_eda.Rmd
+++ b/src/seismophobia_eda.Rmd
@@ -12,6 +12,7 @@ knitr::opts_chunk$set(echo = TRUE)
 ```{r load libraries, message = FALSE}
 library(tidyverse)
 library(here)
+library(ggthemes)
 ```
 
 ```{r raw data, message = FALSE}
@@ -86,3 +87,15 @@ earthquake_fct %>%
         axis.text.x = element_text(angle = 90))
 ```
 
+```{r eda, message=FALSE, warning=FALSE}
+# TODO: choose which correlations to show for EDA
+library(GGally)
+pairs_big <- earthquake_fct %>%
+  ggpairs()
+
+pairs_small <- earthquake_fct %>%
+  select(c(worry_earthquake, experience_earthquake, prepared_earthquake, familliar_san_andreas, familiar_yellowstone, age, gender, household_income)) %>%
+  ggpairs()
+
+pairs_small
+```


### PR DESCRIPTION
@dusty736 

Histogram of target `worry_earthquake` column from previous PR (https://github.com/UBC-MDS/seismophobia/issues/6#issue-747338040) looks beautiful!

I wasn't able to get the 2D histograms to show up on my end. I attempted to use `ggpairs` on selected features to visualize correlation between categorical features (still too many features so the `ggpairs` plot looks too noisy). 

Please see if changes are appropriate and accept pull request. We can also discuss which features look appropriate and which columns may need to be dropped (`worry_big_one` may need to be dropped).