### PR TITLE
Resize 2d histogram output. Reorder levels of worry_earthquake.

### DIFF
--- a/src/seismophobia_eda.Rmd
+++ b/src/seismophobia_eda.Rmd
@@ -22,19 +22,22 @@ glimpse(earthquake)
 
 ```{r minor data wrangling before EDA, message = FALSE}
 earthquake_fct <- earthquake %>%
-  rename(worry_earthquake = 'In general, how worried are you about earthquakes?',
-         worry_big_one = 'How worried are you about the Big One, a massive, catastrophic earthquake?',
-         think_lifetime_big_one = 'Do you think the "Big One" will occur in your lifetime?',
-         experience_earthquake = 'Have you ever experienced an earthquake?',
-         prepared_earthquake = 'Have you or anyone in your household taken any precautions for an earthquake (packed an earthquake survival kit, prepared an evacuation plan, etc.)?',
-         familliar_san_andreas = 'How familiar are you with the San Andreas Fault line?',
-         familiar_yellowstone = 'How familiar are you with the Yellowstone Supervolcano?',
-         age = 'Age',
-         gender = 'What is your gender?',
-         household_income = 'How much total combined money did all members of your HOUSEHOLD earn last year?',
-         us_region = 'US Region') %>%
-  mutate_all(na_if,"") %>% 
-  mutate_if(sapply(earthquake, is.character), as.factor)
+  rename(
+    worry_earthquake = "In general, how worried are you about earthquakes?",
+    worry_big_one = "How worried are you about the Big One, a massive, catastrophic earthquake?",
+    think_lifetime_big_one = 'Do you think the "Big One" will occur in your lifetime?',
+    experience_earthquake = "Have you ever experienced an earthquake?",
+    prepared_earthquake = "Have you or anyone in your household taken any precautions for an earthquake (packed an earthquake survival kit, prepared an evacuation plan, etc.)?",
+    familliar_san_andreas = "How familiar are you with the San Andreas Fault line?",
+    familiar_yellowstone = "How familiar are you with the Yellowstone Supervolcano?",
+    age = "Age",
+    gender = "What is your gender?",
+    household_income = "How much total combined money did all members of your HOUSEHOLD earn last year?",
+    us_region = "US Region"
+  ) %>%
+  mutate_all(na_if, "") %>%
+  mutate_if(sapply(earthquake, is.character), as.factor) %>%
+  mutate(worry_earthquake = fct_relevel(worry_earthquake, c("Extremely worried", "Very worried", "Somewhat worried", "Not so worried", "Not at all worried")))
 
 earthquake_fct
 ```
@@ -70,7 +73,7 @@ earthquake_fct %>%
 ```
 
 
-```{r - 2D Histograms, fig.height=7, fig.width=3}
+```{r - 2D Histograms, fig.height=20, fig.width=10}
 earthquake_fct %>% 
   pivot_longer(!worry_earthquake, names_to = "feature", values_to = "value") %>% 
   add_count(worry_earthquake, feature, value) %>%


### PR DESCRIPTION
The 2D histograms weren't showing due to chunk output size settings. Also reordered factor levels for how worried they are about earthquakes from most worried, to least worried. Makes the plots have a bit of an order. We could reverse this order so the bars go from largest to smallest on the histogram.

Nice plots @dusty736 !