### PR TITLE
Scrape earthquakes counts by US region

### DIFF
--- a/src/scrape_earthquake_counts.R
+++ b/src/scrape_earthquake_counts.R
@@ -1,3 +1,9 @@
+# Scrape Earthquake Counts from the Web by US Census Region
+# by: Dustin Andrews
+# date: 2020/11/20
+# 
+# This needs to be updated for command line usage, and proper integration with original fivethirtyeight dataset script
+# TODO: Make sure this works with the original data set properly and is called as part of initial data collection script
 library(rvest)
 library(here)
 library(tidyverse, quietly = TRUE)

--- a/src/scrape_earthquake_counts.R
+++ b/src/scrape_earthquake_counts.R
@@ -1,0 +1,45 @@
+library(rvest)
+library(here)
+library(tidyverse, quietly = TRUE)
+library(janitor, quietly=TRUE)
+
+region_url <- "https://www.nationsonline.org/oneworld/US-states-by-area.htm"
+earthquake_count_url <- "https://www.usgs.gov/natural-hazards/earthquake-hazards/lists-maps-and-statistics"
+
+xpath_regions <- '//*[@id="statelist"]'
+xpath_earthquake_counts <- '//*[@id="block-system-main"]/div/div/div[2]/div/section[1]/div[3]/div/div/div/div/div/div[5]/div/div/div/div/table'
+
+
+# Table of State -> Region lookups
+regions <- region_url %>% 
+  xml2::read_html() %>% 
+  html_nodes(xpath=xpath_regions) %>% 
+  html_table() %>% 
+  .[[1]] %>% 
+  clean_names() %>% 
+  select(census_region, state)
+
+# Table of Earthquakes per State
+earthquake_counts <- earthquake_count_url %>% 
+  xml2::read_html() %>% 
+  html_nodes(xpath=xpath_earthquake_counts) %>% 
+  html_table() %>% 
+  .[[1]] %>% 
+  clean_names()
+
+
+earthquakes_by_region <- earthquake_counts %>% 
+  left_join(regions, by=c("states"="state")) %>% 
+  pivot_longer(cols=-c(states,census_region)) %>% 
+  rename(us_region = census_region) %>% 
+  group_by(us_region) %>% 
+  summarize(total_earthquakes_2010_2015 = sum(value), .groups='keep')
+
+earthquake <- read_csv(here('data', 'raw', 'earthquake_data.csv')) %>% 
+  clean_names()
+
+earthquake_plus_counts <- earthquake %>% 
+  left_join(earthquakes_by_region, by='us_region')
+
+write_csv(earthquake_plus_counts,here('data','processed','earthquakes_plus_counts.csv'))
+

--- a/src/seismophobia_eda.Rmd
+++ b/src/seismophobia_eda.Rmd
@@ -22,19 +22,22 @@ glimpse(earthquake)
 
 ```{r minor data wrangling before EDA, message = FALSE}
 earthquake_fct <- earthquake %>%
-  rename(worry_earthquake = 'In general, how worried are you about earthquakes?',
-         worry_big_one = 'How worried are you about the Big One, a massive, catastrophic earthquake?',
-         think_lifetime_big_one = 'Do you think the "Big One" will occur in your lifetime?',
-         experience_earthquake = 'Have you ever experienced an earthquake?',
-         prepared_earthquake = 'Have you or anyone in your household taken any precautions for an earthquake (packed an earthquake survival kit, prepared an evacuation plan, etc.)?',
-         familliar_san_andreas = 'How familiar are you with the San Andreas Fault line?',
-         familiar_yellowstone = 'How familiar are you with the Yellowstone Supervolcano?',
-         age = 'Age',
-         gender = 'What is your gender?',
-         household_income = 'How much total combined money did all members of your HOUSEHOLD earn last year?',
-         us_region = 'US Region') %>%
-  mutate_all(na_if,"") %>% 
-  mutate_if(sapply(earthquake, is.character), as.factor)
+  rename(
+    worry_earthquake = "In general, how worried are you about earthquakes?",
+    worry_big_one = "How worried are you about the Big One, a massive, catastrophic earthquake?",
+    think_lifetime_big_one = 'Do you think the "Big One" will occur in your lifetime?',
+    experience_earthquake = "Have you ever experienced an earthquake?",
+    prepared_earthquake = "Have you or anyone in your household taken any precautions for an earthquake (packed an earthquake survival kit, prepared an evacuation plan, etc.)?",
+    familliar_san_andreas = "How familiar are you with the San Andreas Fault line?",
+    familiar_yellowstone = "How familiar are you with the Yellowstone Supervolcano?",
+    age = "Age",
+    gender = "What is your gender?",
+    household_income = "How much total combined money did all members of your HOUSEHOLD earn last year?",
+    us_region = "US Region"
+  ) %>%
+  mutate_all(na_if, "") %>%
+  mutate_if(sapply(earthquake, is.character), as.factor) %>%
+  mutate(worry_earthquake = fct_relevel(worry_earthquake, c("Extremely worried", "Very worried", "Somewhat worried", "Not so worried", "Not at all worried")))
 
 earthquake_fct
 ```
@@ -70,7 +73,7 @@ earthquake_fct %>%
 ```
 
 
-```{r - 2D Histograms, fig.height=7, fig.width=3}
+```{r - 2D Histograms, fig.height=20, fig.width=10}
 earthquake_fct %>% 
   pivot_longer(!worry_earthquake, names_to = "feature", values_to = "value") %>% 
   add_count(worry_earthquake, feature, value) %>%


### PR DESCRIPTION
Grab count of magnitude 3+ earthquakes by US region using `rvest` and two web sources:

USGS Earth counts by state (scroll down to see table by state for 2010-2015):
https://www.usgs.gov/natural-hazards/earthquake-hazards/lists-maps-and-statistics

State to US Region lookup using:
https://www.nationsonline.org/oneworld/US-states-by-area.htm

I found a reference in the `fivethirtyeight` article to the data of survey being May 26-27, 2015. I think these counts could be an interesting feature as they are mostly preceding the survey (other than earthquakes after May of 2015 potentially).

I got it working fully to join the counts onto the original dataset, with no mismatches in region name.
@trevorki I think this step could just be part of the initial data load script. I can do the docopt setup on this if need be

Let me know what you think!